### PR TITLE
Mysql : remove legacy connection

### DIFF
--- a/shaarli/init.php
+++ b/shaarli/init.php
@@ -13,8 +13,7 @@ class Shaarli extends Plugin {
 
   function init($host) {
     $this->host = $host;
-    $this->dbh = $host->get_dbh();
-
+    
     $host->add_hook($host::HOOK_ARTICLE_BUTTON, $this);
     $host->add_hook($host::HOOK_PREFS_TAB, $this);
   }
@@ -77,7 +76,7 @@ class Shaarli extends Plugin {
   function getShaarli() {
     $id = db_escape_string($_REQUEST['id']);
 
-    $result = $this->dbh->query("SELECT title, link
+    $result = db_query("SELECT title, link
                       FROM ttrss_entries, ttrss_user_entries
                       WHERE id = '$id' AND ref_id = id AND owner_uid = " .$_SESSION['uid']);
 


### PR DESCRIPTION
Based on errors reported by tt-rss, and on similar plugins (pocket, tweet, etc.) these lines need to be modified to use the current DB connection scheme.

Without this change, tt-rss throw 1024 (E_NOTICE) exceptions :
plugins.local/shaarli/init.php:22 : Legacy connection